### PR TITLE
No Warnings/Errors when Compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(KnightKing)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(KnightKing)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(KTK_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 option(WITH_TESTS "Build unit test programs" OFF)
 
@@ -28,9 +31,6 @@ if(WITH_TESTS)
     link_directories(${CMAKE_BINARY_DIR}/lib)
     set(GTEST_LIBRARIES "gtest" "gtest_main")
 endif()
-
-#use c++11
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${KTK_RUNTIME_OUTPUT_DIRECTORY})
 


### PR DESCRIPTION
Hello dear KnightKing Maintainers,

trying to compile the program (including tests) I ran into some warnings and errors which shall be fixed when merging this PR. I addressed several warnings and errors occurring when trying to compile KnightKing using GCC 11.4 on Ubuntu 22.04.

- fixing a warning where the CMake minimum required version must be set to >= 2.8.12 for compatibility reasons
- using gtest v1.13.x (submodule update) fixing warnings and errors during compilation of test target
- using C++11 and not the C++0x flag to be able to compile the gtest v1.13.x 

Please just leave me a comment if something is unexpected or requires further discussion and work.